### PR TITLE
Fixed Project Demo Link input filed no showing in Project Subbmission Form

### DIFF
--- a/src/components/ui/auto-form/AutoFormField.vue
+++ b/src/components/ui/auto-form/AutoFormField.vue
@@ -24,6 +24,10 @@ const delegatedProps = computed(() => {
 const { isDisabled, isHidden, isRequired, overrideOptions } = useDependencies(
   props.fieldName
 )
+
+const fieldLabel = computed(() => {
+  return props.config?.label || props.shape.schema?.description || props.fieldName
+})
 </script>
 
 <template>
@@ -37,7 +41,7 @@ const { isDisabled, isHidden, isRequired, overrideOptions } = useDependencies(
     "
     v-if="!isHidden"
     :field-name="fieldName"
-    :label="shape.schema?.description"
+    :label="fieldLabel"
     :required="isRequired || shape.required"
     :options="overrideOptions || shape.options"
     :disabled="isDisabled"

--- a/src/pages/SubmitGoogleSummerOfCodeDetailsPage.vue
+++ b/src/pages/SubmitGoogleSummerOfCodeDetailsPage.vue
@@ -51,6 +51,8 @@
                 placeholder: 'johndoe',
               },
             },
+            
+
           }"
           @submit="handleSubmit"
         >

--- a/src/pages/SubmitProjectDetailsPage.vue
+++ b/src/pages/SubmitProjectDetailsPage.vue
@@ -23,8 +23,7 @@
           :field-config="{
             name: {
               label: 'Full Name',
-              description:
-                'Enter your full name as registered with the college',
+              description: 'Enter your full name as registered with the college',
               inputProps: {
                 placeholder: 'Raja Ravi Varma',
               },
@@ -54,11 +53,13 @@
                   'Include:\n- Problem statement\n- Solution approach\n- Technologies used\n- Current progress\n- Future plans',
               },
             },
-            projectLink: {
+            projectDemoLink: {
               label: 'Project Demo Link',
-              description: 'Link to your deployed project (if available)',
+              description: 'Link to your deployed project demo (if available)',
+              component: 'string',
               inputProps: {
-                placeholder: 'https://my-project.com',
+                type: 'url',
+                placeholder: 'https://demo.my-project.com',
               },
             },
             projectGithubLink: {
@@ -119,7 +120,7 @@ const schema = z.object({
       100,
       'Please provide a more detailed description (minimum 100 characters)'
     ),
-  projectLink: z
+  projectDemoLink: z
     .string()
     .url('Must be a valid URL')
     .optional()


### PR DESCRIPTION
Fixed Project Demo Link field not showing to submission form

- Fixed component rendering by adding `component: 'string'` type
- Updated schema and field config to handle URL validation

The form now has a clear way for students to share their deployed project demos while keeping the submission process simple.

Tested form submission with and without demo links.