### PR TITLE
Fix: Project Demo Link field not rendering in submission form

### DIFF
--- a/src/components/ui/auto-form/AutoFormField.vue
+++ b/src/components/ui/auto-form/AutoFormField.vue
@@ -16,13 +16,15 @@ function isValidConfig(config: any): config is ConfigItem {
   return config && (config.component || config.label || config.inputProps)
 }
 
-console.log('Field props:', {
-  fieldName: props.fieldName,
-  shape: props.shape,
-  config: props.config,
-  type: props.shape?.type,
-  defaultHandler: DEFAULT_ZOD_HANDLERS[props.shape?.type],
-})
+
+// FOR Debugging
+// console.log('Field props:', {
+//   fieldName: props.fieldName,
+//   shape: props.shape,
+//   config: props.config,
+//   type: props.shape?.type,
+//   defaultHandler: DEFAULT_ZOD_HANDLERS[props.shape?.type],
+// })
 
 const inputComponent = computed(() => {
   if (props.config?.component) {

--- a/src/components/ui/auto-form/AutoFormField.vue
+++ b/src/components/ui/auto-form/AutoFormField.vue
@@ -4,6 +4,7 @@ import type { Config, ConfigItem, Shape } from './interface'
 import { computed } from 'vue'
 import { DEFAULT_ZOD_HANDLERS, INPUT_COMPONENTS } from './constant'
 import useDependencies from './dependencies'
+import AutoFormFieldInput from './AutoFormFieldInput.vue'
 
 const props = defineProps<{
   fieldName: string
@@ -12,13 +13,51 @@ const props = defineProps<{
 }>()
 
 function isValidConfig(config: any): config is ConfigItem {
-  return !!config?.component
+  return config && (config.component || config.label || config.inputProps)
 }
 
+console.log('Field props:', {
+  fieldName: props.fieldName,
+  shape: props.shape,
+  config: props.config,
+  type: props.shape?.type,
+  defaultHandler: DEFAULT_ZOD_HANDLERS[props.shape?.type],
+})
+
+const inputComponent = computed(() => {
+  if (props.config?.component) {
+    return typeof props.config.component === 'string'
+      ? INPUT_COMPONENTS[props.config.component]
+      : props.config.component
+  }
+
+  if (props.shape?.schema?._def.typeName === 'ZodString' &&
+      props.shape.schema._def.checks?.some((check: any) => check.kind === 'url')) {
+    return AutoFormFieldInput
+  }
+
+  const defaultHandler = DEFAULT_ZOD_HANDLERS[props.shape?.type] || 'input'
+  return INPUT_COMPONENTS[defaultHandler] || AutoFormFieldInput
+})
+
 const delegatedProps = computed(() => {
-  if (['ZodObject', 'ZodArray'].includes(props.shape?.type))
-    return { schema: props.shape?.schema }
-  return undefined
+  const baseProps = props.shape?.type === 'ZodObject' || props.shape?.type === 'ZodArray'
+    ? { schema: props.shape?.schema }
+    : {}
+
+  if (props.shape?.schema?._def.typeName === 'ZodString' &&
+      props.shape.schema._def.checks?.some((check: any) => check.kind === 'url')) {
+    return {
+      ...baseProps,
+      ...props.config?.inputProps,
+      type: 'url'
+    }
+  }
+
+  return {
+    ...baseProps,
+    ...props.config?.inputProps
+  }
 })
 
 const { isDisabled, isHidden, isRequired, overrideOptions } = useDependencies(
@@ -28,16 +67,11 @@ const { isDisabled, isHidden, isRequired, overrideOptions } = useDependencies(
 
 <template>
   <component
-    :is="
-      isValidConfig(config)
-        ? typeof config.component === 'string'
-          ? INPUT_COMPONENTS[config.component!]
-          : config.component
-        : INPUT_COMPONENTS[DEFAULT_ZOD_HANDLERS[shape.type]]
-    "
+    :is="inputComponent"
     v-if="!isHidden"
     :field-name="fieldName"
-    :label="shape.schema?.description"
+    :label="config?.label"
+    :description="config?.description"
     :required="isRequired || shape.required"
     :options="overrideOptions || shape.options"
     :disabled="isDisabled"


### PR DESCRIPTION
Title:
Fix: Project Demo Link field not rendering in submission form

Description:
The project demo link field wasn't rendering due to strict component validation 
and incomplete URL field handling in AutoFormField.vue.

Changes:
- Enhanced isValidConfig to recognize fields with labels and inputProps
- Added dedicated URL input handling logic
- Refactored component selection into computed property
- Improved template binding for input components

All changes contained in AutoFormField.vue